### PR TITLE
Improved ability for custom templates to use any player and styling

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,6 +145,28 @@ module.exports = function( grunt ) {
 			}
 		},
 
+        concat: {
+            js: {
+                files: {
+                    'assets/js/cue.min.js': [
+                        'assets/js/cue-mejs.js',
+                        'assets/js/cue-media-classes.js',
+                        'assets/js/cue.js'
+                    ],
+                    'admin/assets/js/cue.min.js': [
+                        'admin/assets/js/cue.js',
+                        'admin/assets/js/workflows.js',
+                        'admin/assets/js/models.js',
+                        'admin/assets/js/views.js'
+                    ],
+                },
+            },
+        },
+
+        clean: {
+            compiled: ['assets/**/*.min.*', 'assets/**/*.min.*', '!**/vendor/*.min.*']
+        },
+
 		watch: {
 			js: {
 				files: [ '<%= jshint.plugin %>' ],
@@ -162,6 +184,8 @@ module.exports = function( grunt ) {
 
 	});
 
-	grunt.registerTask( 'default', [ 'jshint', 'uglify', 'sass', 'postcss', 'cssmin', 'watch' ]);
+	grunt.registerTask( 'release', [ 'clean', 'jshint', 'uglify', 'sass', 'postcss', 'cssmin', 'watch' ]);
+
+    grunt.registerTask( 'default', [ 'clean', 'jshint', 'concat', 'sass', 'postcss' ]);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -186,6 +186,6 @@ module.exports = function( grunt ) {
 
 	grunt.registerTask( 'release', [ 'clean', 'jshint', 'uglify', 'sass', 'postcss', 'cssmin', 'watch' ]);
 
-    grunt.registerTask( 'default', [ 'clean', 'jshint', 'concat', 'sass', 'postcss' ]);
+    grunt.registerTask( 'default', [ 'clean', 'jshint', 'concat', 'sass', 'postcss', 'watch' ]);
 
 };

--- a/includes/class-cue.php
+++ b/includes/class-cue.php
@@ -96,7 +96,7 @@ class Cue {
 			'not_found_in_trash' => __( 'No playlists found in Trash.', 'cue' ),
 			'all_items'          => __( 'All Playlists', 'cue' ),
 			'menu_name'          => __( 'Playlists', 'cue' ),
-			'name_admin_bar'     => _x( 'Playlist', 'add new on admin bar', 'cue' )
+			'name_admin_bar'     => _x( 'Playlist', 'add new on admin bar', 'cue' ),
 		);
 
 		$args = array(
@@ -213,7 +213,7 @@ class Cue {
 			$args
 		);
 		?>
-		<script type="application/json" class="cue-playlist-data"><?php echo json_encode( $settings ); ?></script>
+		<script type="application/json" class="cue-playlist-data"><?php echo wp_json_encode( $settings ); ?></script>
 		<?php
 	}
 
@@ -315,6 +315,6 @@ class Cue {
 	 */
 	protected function shortcode_bool( $var ) {
 		$falsey = array( 'false', '0', 'no', 'n' );
-		return ( ! $var || in_array( strtolower( $var ), $falsey ) ) ? false : true;
+		return ( ! $var || in_array( strtolower( $var ), $falsey, true ) ) ? false : true;
 	}
 }

--- a/includes/class-cue.php
+++ b/includes/class-cue.php
@@ -191,6 +191,8 @@ class Cue {
 	 * @param array $args
 	 */
 	public function print_playlist_settings( $playlist, $tracks, $args ) {
+        if ( isset( $args['print_playlist_data'] ) && ! $args['print_playlist_data'] ) return;
+
 		$thumbnail = '';
 		if ( has_post_thumbnail( $playlist->ID ) ) {
 			$thumbnail_id = get_post_thumbnail_id( $playlist->ID );

--- a/includes/class-cue.php
+++ b/includes/class-cue.php
@@ -191,7 +191,9 @@ class Cue {
 	 * @param array $args
 	 */
 	public function print_playlist_settings( $playlist, $tracks, $args ) {
-        if ( isset( $args['print_playlist_data'] ) && ! $args['print_playlist_data'] ) return;
+		if ( isset( $args['print_data'] ) && ! $args['print_data'] ) {
+			return;
+		}
 
 		$thumbnail = '';
 		if ( has_post_thumbnail( $playlist->ID ) ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -58,11 +58,19 @@ function cue_playlist( $post, $args = array() ) {
 	$classes[] = ( isset( $args['show_playlist'] ) && false == $args['show_playlist'] ) ? 'is-playlist-hidden' : '';
 	$classes   = implode( ' ', array_filter( $classes ) );
 
+    if ( ! isset( $args['container'] ) || isset( $args['container'] ) && $args['container'] ) {
+        echo '<div class="cue-playlist-container">';
+    }
+
     do_action( 'cue_before_playlist', $post, $tracks, $args );
 
     include( $template );
 
     do_action( 'cue_after_playlist', $post, $tracks, $args );
+
+    if ( ! isset( $args['container'] ) || isset( $args['container'] ) && $args['container'] ) {
+        echo '</div>';
+    }
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -50,7 +50,7 @@ function cue_playlist( $post, $args = array() ) {
 	$template_names = array(
 		"playlist-{$post->ID}.php",
 		"playlist-{$post->post_name}.php",
-		"playlist.php",
+		'playlist.php',
 	);
 
 	// Prepend custom templates.
@@ -144,7 +144,7 @@ function get_cue_default_track() {
  * @return array
  */
 function sanitize_cue_track( $track, $context = 'display' ) {
-	if ( 'save' == $context ) {
+	if ( 'save' === $context ) {
 		$valid_props = get_cue_default_track();
 
 		// Remove properties that aren't in the whitelist.
@@ -181,7 +181,7 @@ function cue_player( $player_id, $args = array() ) {
 		'player'   => $player_id,
 		'template' => array(
 			"player-{$player_id}.php",
-			"player.php",
+			'player.php',
 		),
 	);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -35,7 +35,15 @@ function cue_playlist( $post, $args = array() ) {
 		return;
 	}
 
-	if ( ! isset( $args['enqueue'] ) || $args['enqueue'] ) {
+	$args = wp_parse_args( $args, array(
+		'container'     => true,
+		'enqueue'       => true,
+		'print_data'    => true,
+		'show_playlist' => true,
+		'template'      => '',
+	) );
+
+	if ( $args['enqueue'] ) {
 		Cue::enqueue_assets();
 	}
 
@@ -55,22 +63,22 @@ function cue_playlist( $post, $args = array() ) {
 	$template = $template_loader->locate_template( $template_names );
 
 	$classes   = array( 'cue-playlist' );
-	$classes[] = ( isset( $args['show_playlist'] ) && false == $args['show_playlist'] ) ? 'is-playlist-hidden' : '';
+	$classes[] = ( $args['show_playlist'] ) ? '' : 'is-playlist-hidden';
 	$classes   = implode( ' ', array_filter( $classes ) );
 
-    if ( ! isset( $args['container'] ) || isset( $args['container'] ) && $args['container'] ) {
-        echo '<div class="cue-playlist-container">';
-    }
+	if ( $args['container'] ) {
+		echo '<div class="cue-playlist-container">';
+	}
 
-    do_action( 'cue_before_playlist', $post, $tracks, $args );
+	do_action( 'cue_before_playlist', $post, $tracks, $args );
 
-    include( $template );
+	include( $template );
 
-    do_action( 'cue_after_playlist', $post, $tracks, $args );
+	do_action( 'cue_after_playlist', $post, $tracks, $args );
 
-    if ( ! isset( $args['container'] ) || isset( $args['container'] ) && $args['container'] ) {
-        echo '</div>';
-    }
+	if ( $args['container'] ) {
+		echo '</div>';
+	}
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -58,15 +58,11 @@ function cue_playlist( $post, $args = array() ) {
 	$classes[] = ( isset( $args['show_playlist'] ) && false == $args['show_playlist'] ) ? 'is-playlist-hidden' : '';
 	$classes   = implode( ' ', array_filter( $classes ) );
 
-	echo '<div class="cue-playlist-container">';
+    do_action( 'cue_before_playlist', $post, $tracks, $args );
 
-		do_action( 'cue_before_playlist', $post, $tracks, $args );
+    include( $template );
 
-		include( $template );
-
-		do_action( 'cue_after_playlist', $post, $tracks, $args );
-
-	echo '</div>';
+    do_action( 'cue_after_playlist', $post, $tracks, $args );
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "devDependencies": {
     "autoprefixer": "^6.2.3",
     "grunt": "~0.4.5",
+    "grunt-contrib-clean": "^0.7.0",
+    "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-cssmin": "~0.14.0",
     "grunt-contrib-jshint": "~0.11.3",
     "grunt-contrib-uglify": "~0.11.0",

--- a/templates/playlist.php
+++ b/templates/playlist.php
@@ -1,22 +1,24 @@
-<div class="<?php echo esc_attr( $classes ); ?>" itemscope itemtype="http://schema.org/MusicPlaylist">
-	<meta itemprop="numTracks" content="<?php echo count( $tracks ); ?>" />
+<div class="cue-playlist-container">
+    <div class="<?php echo esc_attr( $classes ); ?>" itemscope itemtype="http://schema.org/MusicPlaylist">
+        <meta itemprop="numTracks" content="<?php echo count( $tracks ); ?>" />
 
-	<audio src="<?php echo esc_url( $tracks[0]['audioUrl'] ); ?>" controls preload="none" class="cue-audio" style="width: 100%; height: auto"></audio>
+        <audio src="<?php echo esc_url( $tracks[0]['audioUrl'] ); ?>" controls preload="none" class="cue-audio" style="width: 100%; height: auto"></audio>
 
-	<ol class="cue-tracks">
-		<?php foreach ( $tracks as $track ) : ?>
-			<li class="cue-track" itemprop="track" itemscope itemtype="http://schema.org/MusicRecording">
-				<?php do_action( 'cue_playlist_track_top', $track, $post, $args ); ?>
+        <ol class="cue-tracks">
+            <?php foreach ( $tracks as $track ) : ?>
+                <li class="cue-track" itemprop="track" itemscope itemtype="http://schema.org/MusicRecording">
+                    <?php do_action( 'cue_playlist_track_top', $track, $post, $args ); ?>
 
-				<span class="cue-track-details cue-track-cell">
-					<span class="cue-track-title" itemprop="name"><?php echo $track['title']; ?></span>
-					<span class="cue-track-artist" itemprop="byArtist"><?php echo esc_html( $track['artist'] ); ?></span>
-				</span>
+                    <span class="cue-track-details cue-track-cell">
+                        <span class="cue-track-title" itemprop="name"><?php echo $track['title']; ?></span>
+                        <span class="cue-track-artist" itemprop="byArtist"><?php echo esc_html( $track['artist'] ); ?></span>
+                    </span>
 
-				<span class="cue-track-length cue-track-cell"><?php echo esc_html( $track['length'] ); ?></span>
+                    <span class="cue-track-length cue-track-cell"><?php echo esc_html( $track['length'] ); ?></span>
 
-				<?php do_action( 'cue_playlist_track_bottom', $track, $post, $args ); ?>
-			</li>
-		<?php endforeach; ?>
-	</ol>
+                    <?php do_action( 'cue_playlist_track_bottom', $track, $post, $args ); ?>
+                </li>
+            <?php endforeach; ?>
+        </ol>
+    </div>
 </div>

--- a/templates/playlist.php
+++ b/templates/playlist.php
@@ -1,24 +1,22 @@
-<div class="cue-playlist-container">
-    <div class="<?php echo esc_attr( $classes ); ?>" itemscope itemtype="http://schema.org/MusicPlaylist">
-        <meta itemprop="numTracks" content="<?php echo count( $tracks ); ?>" />
+<div class="<?php echo esc_attr( $classes ); ?>" itemscope itemtype="http://schema.org/MusicPlaylist">
+	<meta itemprop="numTracks" content="<?php echo count( $tracks ); ?>" />
 
-        <audio src="<?php echo esc_url( $tracks[0]['audioUrl'] ); ?>" controls preload="none" class="cue-audio" style="width: 100%; height: auto"></audio>
+	<audio src="<?php echo esc_url( $tracks[0]['audioUrl'] ); ?>" controls preload="none" class="cue-audio" style="width: 100%; height: auto"></audio>
 
-        <ol class="cue-tracks">
-            <?php foreach ( $tracks as $track ) : ?>
-                <li class="cue-track" itemprop="track" itemscope itemtype="http://schema.org/MusicRecording">
-                    <?php do_action( 'cue_playlist_track_top', $track, $post, $args ); ?>
+	<ol class="cue-tracks">
+		<?php foreach ( $tracks as $track ) : ?>
+			<li class="cue-track" itemprop="track" itemscope itemtype="http://schema.org/MusicRecording">
+				<?php do_action( 'cue_playlist_track_top', $track, $post, $args ); ?>
 
-                    <span class="cue-track-details cue-track-cell">
-                        <span class="cue-track-title" itemprop="name"><?php echo $track['title']; ?></span>
-                        <span class="cue-track-artist" itemprop="byArtist"><?php echo esc_html( $track['artist'] ); ?></span>
-                    </span>
+				<span class="cue-track-details cue-track-cell">
+					<span class="cue-track-title" itemprop="name"><?php echo $track['title']; ?></span>
+					<span class="cue-track-artist" itemprop="byArtist"><?php echo esc_html( $track['artist'] ); ?></span>
+				</span>
 
-                    <span class="cue-track-length cue-track-cell"><?php echo esc_html( $track['length'] ); ?></span>
+				<span class="cue-track-length cue-track-cell"><?php echo esc_html( $track['length'] ); ?></span>
 
-                    <?php do_action( 'cue_playlist_track_bottom', $track, $post, $args ); ?>
-                </li>
-            <?php endforeach; ?>
-        </ol>
-    </div>
+				<?php do_action( 'cue_playlist_track_bottom', $track, $post, $args ); ?>
+			</li>
+		<?php endforeach; ?>
+	</ol>
 </div>


### PR DESCRIPTION
I've spent a significant amount of time digging into the code of this plugin in an attempt to have a custom player on the front end but using the admin functionality of Cue for managing my playlists. The commits represented by this pull request make it possible to completely replace the front-end of Cue with something else.

With these proposed changes, this can be done by implementing the `cue_playlist_tracks` filter to manipulate the track data to be however I want it to be and then calling the `cue_playlist` function in the following way:

`$playlist_args = array('enqueue'  => false, 'print_playlist_data' => false, 'container' => false, 'template' => array("custom-playlist.php"));`
`echo cue_playlist($playlist['ID'], $playlist_args);`

The `custom-playlist.php` file then has full control over the data sent to the client as well as how to display that data. Before these changes, there was no way to opt out of sending the enclosing `<div class="cue-playlist-container">` container and or the `cue-playlist-data` script block to the client.

By implementing both of these changes in the `$args` array, none of these changes breaks backwards compatibility with sites that employ custom templates under the current setup.