### PR TITLE
Add 'container' argument to cue_playlist function

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -35,7 +35,15 @@ function cue_playlist( $post, $args = array() ) {
 		return;
 	}
 
-	if ( ! isset( $args['enqueue'] ) || $args['enqueue'] ) {
+	$args = wp_parse_args( $args, array(
+		'container'     => true,
+		'enqueue'       => true,
+		'show_playlist' => true,
+		'player'        => '',
+		'template'      => '',
+	) );
+
+	if ( $args['enqueue'] ) {
 		Cue::enqueue_assets();
 	}
 
@@ -55,18 +63,22 @@ function cue_playlist( $post, $args = array() ) {
 	$template = $template_loader->locate_template( $template_names );
 
 	$classes   = array( 'cue-playlist' );
-	$classes[] = ( isset( $args['show_playlist'] ) && false == $args['show_playlist'] ) ? 'is-playlist-hidden' : '';
+	$classes[] = ( $args['show_playlist'] ) ? '' : 'is-playlist-hidden';
 	$classes   = implode( ' ', array_filter( $classes ) );
 
-	echo '<div class="cue-playlist-container">';
+	if ( $args['container'] ) {
+		echo '<div class="cue-playlist-container">';
+	}
 
-		do_action( 'cue_before_playlist', $post, $tracks, $args );
+	do_action( 'cue_before_playlist', $post, $tracks, $args );
 
-		include( $template );
+	include( $template );
 
-		do_action( 'cue_after_playlist', $post, $tracks, $args );
+	do_action( 'cue_after_playlist', $post, $tracks, $args );
 
-	echo '</div>';
+	if ( $args['container'] ) {
+		echo '</div>';
+	}
 }
 
 /**


### PR DESCRIPTION
@bradyvercher, I've worked at separating out the changes I've made into distinct commits as you suggested [here](https://github.com/audiotheme/cue/pull/8#issuecomment-184387916). This commit sets up default arg settings in the `cue_playlist` function as well as added another argument called `container` that allows a consumer of the Cue plugin to turn off output of the `cue-playlist-container` div. As part of the default args, I also removed code that was no longer necessary since we set the args to a known default. Thanks!