### PR TITLE
Add 'print_data' argument to cue_playlist function

### DIFF
--- a/includes/class-cue.php
+++ b/includes/class-cue.php
@@ -191,6 +191,10 @@ class Cue {
 	 * @param array $args
 	 */
 	public function print_playlist_settings( $playlist, $tracks, $args ) {
+		if ( isset( $args['print_data'] ) && ! $args['print_data'] ) {
+			return;
+		}
+
 		$thumbnail = '';
 		if ( has_post_thumbnail( $playlist->ID ) ) {
 			$thumbnail_id = get_post_thumbnail_id( $playlist->ID );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -35,6 +35,14 @@ function cue_playlist( $post, $args = array() ) {
 		return;
 	}
 
+	$args = wp_parse_args( $args, array(
+		'enqueue'       => true,
+		'print_data'    => true,
+		'show_playlist' => true,
+		'player'        => '',
+		'template'      => '',
+	) );
+
 	if ( ! isset( $args['enqueue'] ) || $args['enqueue'] ) {
 		Cue::enqueue_assets();
 	}


### PR DESCRIPTION
@bradyvercher, I've worked at separating out the changes I've made into distinct commits as you suggested [here](https://github.com/audiotheme/cue/pull/8#issuecomment-184387916). This commit sets up default arg settings in the `cue_playlist` function as well as added another argument called `print_data` that allows a consumer of the Cue plugin to turn off output of the `cue-playlist-data` script block. There were some other changes in the [container pull request](https://github.com/audiotheme/cue/pull/9) relating to unnecessary code now that we have set defaults on the args. I didn't include those changes here. Thanks!