### PR TITLE
Add 'dev' target to Grunt tasks that does not minify/uglify code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,6 +145,28 @@ module.exports = function( grunt ) {
 			}
 		},
 
+		concat: {
+			js: {
+				files: {
+					'assets/js/cue.min.js': [
+						'assets/js/cue-mejs.js',
+						'assets/js/cue-media-classes.js',
+						'assets/js/cue.js'
+					],
+					'admin/assets/js/cue.min.js': [
+						'admin/assets/js/cue.js',
+						'admin/assets/js/workflows.js',
+						'admin/assets/js/models.js',
+						'admin/assets/js/views.js'
+					],
+				},
+			},
+		},
+
+		clean: {
+			compiled: ['assets/**/*.min.*', 'assets/**/*.min.*', '!**/vendor/*.min.*']
+		},
+
 		watch: {
 			js: {
 				files: [ '<%= jshint.plugin %>' ],
@@ -162,6 +184,8 @@ module.exports = function( grunt ) {
 
 	});
 
-	grunt.registerTask( 'default', [ 'jshint', 'uglify', 'sass', 'postcss', 'cssmin', 'watch' ]);
+	grunt.registerTask( 'default', [ 'clean', 'jshint', 'uglify', 'sass', 'postcss', 'cssmin', 'watch' ]);
+
+	grunt.registerTask( 'dev', [ 'clean', 'jshint', 'concat', 'sass', 'postcss', 'watch' ]);
 
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "devDependencies": {
     "autoprefixer": "^6.2.3",
     "grunt": "~0.4.5",
+    "grunt-contrib-clean": "^0.7.0",
+    "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-cssmin": "~0.14.0",
     "grunt-contrib-jshint": "~0.11.3",
     "grunt-contrib-uglify": "~0.11.0",


### PR DESCRIPTION
@bradyvercher, I've worked at separating out the changes I've made into distinct commits as you suggested [here](https://github.com/audiotheme/cue/pull/8#issuecomment-184387916). This commit adds a `dev` target to the Grunt file that doesn't minify/uglify the code. This makes it easier to debug and also read the generated code for understanding. Thanks!